### PR TITLE
Implement better logging

### DIFF
--- a/angrcutter/plugin_interface.py
+++ b/angrcutter/plugin_interface.py
@@ -1,8 +1,9 @@
 import cutter
 
-from .plugin import AngrWidget
+from .plugin import AngrWidget, printMessage, LogLevel
 
 from PySide2.QtWidgets import QAction
+
 
 class angrCutterPlugin(cutter.CutterPlugin):
     name = 'angr-cutter'
@@ -22,8 +23,9 @@ class angrCutterPlugin(cutter.CutterPlugin):
     def terminate(self):
         pass
 
+
 def create_cutter_plugin():
     try:
         return angrCutterPlugin()
     except Exception as e:
-        print("[angr-cutter]: " + traceback.format_exc())
+        printMessage(traceback.format_exc(), LogLevel.ERROR)


### PR DESCRIPTION
This pr implements a better logging mechanism. 

In general, I suggest using the `logging` library, or elementals. Especially if you're planning to keep maintaining the plugin
currently, there are ~15 prints so it's not a big deal to use the enum I did with a printing function
but logger would be nice if you'd want to log stuff to a log file (for verbose output, debug purposes, etc), have better control of logging level, etc. For some symbolization one would want to find a big buffer *and not only 100bytes), thus, logging it to a file is a great option.


This pr also apply pep8 formatting